### PR TITLE
Add flag -p in logging time

### DIFF
--- a/build/MiBench/scripts/run.sh
+++ b/build/MiBench/scripts/run.sh
@@ -76,7 +76,7 @@ function runBenchmark {
   commandToRunSplit="${binary} ${args}" ;
   echo "Running: ${commandToRunSplit} in ${PWD}" ;
   # eval perf stat ${commandToRunSplit} > ${perfStatFile} ;
-  eval /usr/bin/time ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
+  eval /usr/bin/time -p ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
   if [ "$?" != 0 ] ; then
     echo "ERROR: run of ${commandToRunSplit} failed." ;
     return ;

--- a/build/NAS/scripts/run.sh
+++ b/build/NAS/scripts/run.sh
@@ -75,7 +75,7 @@ function runBenchmark {
   commandToRunSplit="${binary}" ;
   echo "Running: ${commandToRunSplit} in ${PWD}" ;
   # eval perf stat ${commandToRunSplit} > ${perfStatFile} ;
-  eval /usr/bin/time ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
+  eval /usr/bin/time -p ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
   if [ "$?" != 0 ] ; then
     echo "ERROR: run of ${commandToRunSplit} failed." ;
     return ;

--- a/build/PARSEC3/scripts/run.sh
+++ b/build/PARSEC3/scripts/run.sh
@@ -53,7 +53,7 @@ function runBenchmark {
   commandToRunSplit="./${benchmarkArg} ${run_args}" ;
   echo "Running: ${commandToRunSplit} in ${PWD}" ;
   # eval perf stat ${commandToRunSplit} > ${perfStatFile} ;
-  eval /usr/bin/time ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
+  eval /usr/bin/time -p ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
   if [ "$?" != 0 ] ; then
     echo "ERROR: run of ${commandToRunSplit} failed." ;
     exit 1 ;

--- a/build/PolyBench/scripts/run.sh
+++ b/build/PolyBench/scripts/run.sh
@@ -20,7 +20,7 @@ function runBenchmark {
   commandToRunSplit="./${benchmarkArg}" ;
   echo "Running: ${commandToRunSplit} in ${PWD}" ;
   # eval perf stat ${commandToRunSplit} > ${perfStatFile} ;
-  eval /usr/bin/time ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
+  eval /usr/bin/time -p ${commandToRunSplit} 2>&1 > ${perfStatFile} ;
   if [ "$?" != 0 ] ; then
     echo "ERROR: run of ${commandToRunSplit} failed." ;
     exit 1 ;

--- a/build/SPEC2017/scripts/run.sh
+++ b/build/SPEC2017/scripts/run.sh
@@ -18,7 +18,7 @@ function runBenchmark {
 	echo "Running \"${1}\" with \"${1}_newbin ${arguments} >${1}_${inputsize}_output.txt\""
 	# ${BENCHMARKS_DIR}/${1}/${1}_newbin ${arguments} >${BENCHMARKS_DIR}/${1}/${1}_${inputsize}_output.txt
 	# perf stat ../${1}_newbin ${arguments} >${BENCHMARKS_DIR}/${1}/${1}_${inputsize}_output.txt
-	eval /usr/bin/time ../${1}_newbin ${arguments} 2>&1 >${BENCHMARKS_DIR}/${1}/${1}_${inputsize}_output.txt ;
+	eval /usr/bin/time -p ../${1}_newbin ${arguments} 2>&1 >${BENCHMARKS_DIR}/${1}/${1}_${inputsize}_output.txt ;
   exitOutput=$? ;
 	echo `tail -n 2 ${BENCHMARKS_DIR}/${1}/${1}_${inputsize}_output.txt`
 	echo "--------------------------------------------------------------------------------------"


### PR DESCRIPTION
Add `-p` flag to /usr/bin/time to print POSIX standard 1003.2 conformant string:
```
real %%e
user %%U
sys %%S
```
for example, using
```
real 34.04
user 33.93
sys 0.01
```
instead of
```
8122.96user 27.40system 2:16:15elapsed 99%CPU (0avgtext+0avgdata 7177332maxresident)k
472inputs+96696outputs (1major+4911769minor)pagefaults 0swaps
```