### PR TITLE
Print program outputs for NAS

### DIFF
--- a/build/NAS/scripts/run.sh
+++ b/build/NAS/scripts/run.sh
@@ -82,7 +82,7 @@ function runBenchmark {
   fi
 
   # Print last line of perf stat output file
-  echo `tail -n 2 ${perfStatFile}` ;
+  cat ${perfStatFile} ;
 	echo "--------------------------------------------------------------------------------------" ;
 
   return ;


### PR DESCRIPTION
NAS benchmarks output contains a row "Time in seconds  = xxx". Printing the whole output to extract the time result later in the noelleGym pipeline.
Related pull request: https://github.com/arcana-lab/noelleGym/pull/5