### PR TITLE
MiBench fix

### DIFF
--- a/build/MiBench/Makefile
+++ b/build/MiBench/Makefile
@@ -21,7 +21,7 @@ bitcode_copy: MiBench
 	./scripts/bitcode_copy.sh
 
 setup: MiBench
-	./scripts/setup.sh
+	./scripts/setup.sh $(BENCHMARK)
 
 optimization: MiBench
 	./scripts/optimization.sh $(BENCHMARK)

--- a/build/MiBench/patches/MiBench/telecomm/adpcm/runme_rawcaudio.sh
+++ b/build/MiBench/patches/MiBench/telecomm/adpcm/runme_rawcaudio.sh
@@ -2,4 +2,4 @@
 
 ./unpack_input.sh "very_large.pcm";
 
-./bin/rawcaudio < data/very_large.pcm > output_very_large.adpcm
+./rawcaudio < data/very_large.pcm > output_very_large.adpcm

--- a/build/MiBench/patches/MiBench/telecomm/adpcm/runme_rawdaudio.sh
+++ b/build/MiBench/patches/MiBench/telecomm/adpcm/runme_rawdaudio.sh
@@ -2,4 +2,4 @@
 
 ./unpack_input.sh "very_large.adpcm";
 
-./bin/rawdaudio < data/very_large.adpcm > output_very_large.pcm
+./rawdaudio < data/very_large.adpcm > output_very_large.pcm

--- a/build/MiBench/patches/MiBench/telecomm/adpcm/src/Makefile
+++ b/build/MiBench/patches/MiBench/telecomm/adpcm/src/Makefile
@@ -27,7 +27,7 @@ ALLSRC=README adpcm.2 Makefile adpcm.h libst.h adpcm.c timing.c rawcaudio.c \
 	rawdaudio.c suncaudio.c sgicaudio.c sgidaudio.c hello.adpcm.uu
 
 all: adpcm.o rawcaudio rawdaudio timing
-	mkdir ../bin
+	mkdir -p ../bin
 	cp rawcaudio rawdaudio timing ../bin/.
 
 sgi: all sgicaudio sgidaudio

--- a/build/MiBench/scripts/run.sh
+++ b/build/MiBench/scripts/run.sh
@@ -19,33 +19,8 @@ function runBenchmark {
   # Get function args
   benchmarkArg="${1}" ;
 
-  # Check if paths exists
-  pathToBenchmark="${PWD_PATH}/benchmarks/${benchmarkArg}" ;
-  if ! test -d ${pathToBenchmark} ; then
-    echo "WARNING: ${pathToBenchmark} not found. Skipping..." ;
-    return ;
-  fi
-
-  pathToBinaryPath="${pathToBenchmark}/path.txt" ;
-  if ! test -f ${pathToBinaryPath} ; then
-    echo "WARNING: ${pathToBinaryPath} not found. Skipping..." ;
-    return ;
-  fi
-
-  pathToBinary=`cat ${pathToBinaryPath}` ;
-  if ! test -d ${pathToBinary} ; then
-    echo "WARNING: ${pathToBinary} not found. Skipping..." ;
-    return ;
-  fi
-
-  currBinary="${pathToBenchmark}/${benchmarkArg}" ;
-  if ! test -f ${currBinary} ; then
-    echo "WARNING: ${currBinary} not found. Skipping..." ;
-    return ;
-  fi
-
-  # Go in the benchmark suite where the script is
-  cd ${pathToBinary} ;
+  # Go in the benchmark dir
+  cd ${benchmarksDir}/${benchmarkArg} ;
 
   # Get arguments of how to run the binary
   runScript="./runme_${benchmarkArg}.sh" ;
@@ -69,8 +44,8 @@ function runBenchmark {
   args=$(split t "${commandToRun}") ;
 
   # Copy binary into benchmark suite (i.e., current directory)
-  echo "Executing ${pathToBinary}/${benchmarkArg}" ;
-  cp ${currBinary} . ;
+  #echo "Executing ${pathToBinary}/${benchmarkArg}" ;
+  #cp ${currBinary} . ;
 
   perfStatFile="${PWD_PATH}/benchmarks/${benchmarkArg}/${benchmarkArg}_large_output.txt" ;
   commandToRunSplit="${binary} ${args}" ;

--- a/build/MiBench/scripts/setup.sh
+++ b/build/MiBench/scripts/setup.sh
@@ -67,11 +67,14 @@ function genInputBenchmark {
     ./unpack_input.sh ;
   fi
 
-  # Run the benchmark
+  # Generate input.txt (needed by noelle autotuner)
   commandToRun=`tail -n 1 ${runScript}` ;
   binary=$(split h "${commandToRun}") ;
   args=$(split t "${commandToRun}") ;
   echo ${args} > input.txt ;
+
+  # The current dir has everything we need to run the program, let's copy it into our benchmarks dir
+  cp -r ./* ${benchmarksDir}/${benchmarkArg}/ ;
 
   return ;
 }

--- a/build/MiBench/scripts/setup.sh
+++ b/build/MiBench/scripts/setup.sh
@@ -4,4 +4,98 @@
 PWD_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.." ;
 benchmarkSuiteName="MiBench" ;
 
+function split {
+  headOrTail="${1}" ;
+  stringToSplit="${2}" ;
+  IFS=' ' ;
+  read -a stringAsArray <<< "${stringToSplit}" ;
+
+  if [ ${headOrTail} == "h" ] ; then
+    echo ${stringAsArray[0]} ;
+  else
+    echo ${stringAsArray[@]:1} ;
+  fi
+
+  return ;
+}
+
+function genInputBenchmark {
+  # Get function args
+  benchmarkArg="${1}" ;
+
+  # Check if paths exists
+  pathToBenchmark="${PWD_PATH}/benchmarks/${benchmarkArg}" ;
+  if ! test -d ${pathToBenchmark} ; then
+    echo "WARNING: ${pathToBenchmark} not found. Skipping..." ;
+    return ;
+  fi
+
+  pathToBinaryPath="${pathToBenchmark}/path.txt" ;
+  if ! test -f ${pathToBinaryPath} ; then
+    echo "WARNING: ${pathToBinaryPath} not found. Skipping..." ;
+    return ;
+  fi
+
+  pathToBinary=`cat ${pathToBinaryPath}` ;
+  if ! test -d ${pathToBinary} ; then
+    echo "WARNING: ${pathToBinary} not found. Skipping..." ;
+    return ;
+  fi
+
+  currBinary="${pathToBenchmark}/${benchmarkArg}" ;
+  if ! test -f ${currBinary} ; then
+    echo "WARNING: ${currBinary} not found. Skipping..." ;
+    return ;
+  fi
+
+  # Go in the benchmark suite where the script is
+  cd ${pathToBinary} ;
+
+  # Get arguments of how to run the binary
+  runScript="./runme_${benchmarkArg}.sh" ;
+  if ! test -f ${runScript} ; then
+    echo "WARNING: ${runScript} not found. Going up one dir." ;
+    cd ../ ;
+    if ! test -f ${runScript} ; then
+      echo "WARNING: ${runScript} not found. Skipping..." ;
+      return ;
+    fi
+  fi
+
+  # Unpack the input if necessary
+  if test -f ./unpack_input.sh ; then
+    ./unpack_input.sh ;
+  fi
+
+  # Run the benchmark
+  commandToRun=`tail -n 1 ${runScript}` ;
+  binary=$(split h "${commandToRun}") ;
+  args=$(split t "${commandToRun}") ;
+  echo ${args} > input.txt ;
+
+  return ;
+}
+
+# Get benchmark suite dir
+PWD_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.." ;
+
+# Get args
+benchmarkToRun="${1}" ;
+
+# Get bitcode benchmark dir
+benchmarksDir="${PWD_PATH}/benchmarks" ;
+if ! test -d ${benchmarksDir} ; then
+  echo "ERROR: ${benchmarksDir} not found. Run make bitcode_copy." ;
+  exit 1 ;
+fi
+
+# Run benchmark
+if [ "${benchmarkToRun}" == "all" ]; then
+	for benchmark in `ls ${benchmarksDir}`; do
+    genInputBenchmark ${benchmark} ;
+	done
+else
+  genInputBenchmark ${benchmarkToRun} ;
+fi
+
 echo "DONE." ;

--- a/build/MiBench/scripts/setup.sh
+++ b/build/MiBench/scripts/setup.sh
@@ -42,12 +42,6 @@ function genInputBenchmark {
     return ;
   fi
 
-  currBinary="${pathToBenchmark}/${benchmarkArg}" ;
-  if ! test -f ${currBinary} ; then
-    echo "WARNING: ${currBinary} not found. Skipping..." ;
-    return ;
-  fi
-
   # Go in the benchmark suite where the script is
   cd ${pathToBinary} ;
 


### PR DESCRIPTION
MiBench benchmarks now run inside their benchmarks/$BENCHMARK dir, instead of inside the MiBench benchmark suite dir, like the other benchmark suites do.
This has the added benefit of having each benchmark run on its own dir.