### PR TITLE
Fixed generation of binaries in MiBench.

### DIFF
--- a/build/MiBench/patches/MiBench/consumer/jpeg/jpeg-6a/Makefile
+++ b/build/MiBench/patches/MiBench/consumer/jpeg/jpeg-6a/Makefile
@@ -136,9 +136,11 @@ libjpeg.a:  $(LIBOBJECTS)
 
 cjpeg: $(COBJECTS) libjpeg.a
 	$(LN) $(LDFLAGS) -o cjpeg $(COBJECTS) libjpeg.a $(LDLIBS) $(SB_OPT)
+	cp cjpeg ..
 
 djpeg: $(DOBJECTS) libjpeg.a
 	$(LN) $(LDFLAGS) -o djpeg $(DOBJECTS) libjpeg.a $(LDLIBS) $(SB_OPT)
+	cp djpeg ..
 
 jpegtran: $(TROBJECTS) libjpeg.a
 	$(LN) $(LDFLAGS) -o jpegtran $(TROBJECTS) libjpeg.a $(LDLIBS)

--- a/build/MiBench/patches/MiBench/consumer/jpeg/runme_cjpeg.sh
+++ b/build/MiBench/patches/MiBench/consumer/jpeg/runme_cjpeg.sh
@@ -2,4 +2,4 @@
 
 ./unpack_input.sh "input_very_large.ppm";
 
-./jpeg-6a/cjpeg -dct int -progressive -opt -outfile output_very_large_encode.jpeg input_very_large.ppm ;
+./cjpeg -dct int -progressive -opt -outfile output_very_large_encode.jpeg input_very_large.ppm ;

--- a/build/MiBench/patches/MiBench/consumer/jpeg/runme_djpeg.sh
+++ b/build/MiBench/patches/MiBench/consumer/jpeg/runme_djpeg.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./jpeg-6a/djpeg -dct int -ppm -outfile output_very_large_decode.ppm input_very_large.jpeg
+./djpeg -dct int -ppm -outfile output_very_large_decode.ppm input_very_large.jpeg

--- a/build/MiBench/patches/MiBench/consumer/lame/lame3.70/Makefile
+++ b/build/MiBench/patches/MiBench/consumer/lame/lame3.70/Makefile
@@ -282,7 +282,8 @@ DEP = $(c_sources:.c=.d)
 #	$(CC) -o $(PGM)  main.o $(OBJ) $(LIBS) $(CPP_OPTS) $(LIBSNDFILE) $(GTKLIBS) $(LIBTERMCAP)
 
 $(PGM):	main.o libmp3lame.a 
-	$(CC) -o $(PGM)  main.o -L. -lmp3lame $(LIBS) $(LIBSNDFILE) $(GTKLIBS) $(LIBTERMCAP) $(SB_OPT) 
+	$(CC) -o $(PGM)  main.o -L. -lmp3lame $(LIBS) $(LIBSNDFILE) $(GTKLIBS) $(LIBTERMCAP) $(SB_OPT)
+	cp $(PGM) ..	
 
 mp3x:	mp3x.o libmp3lame.a
 	$(CC) -o mp3x mp3x.o  $(OBJ) $(LIBS) $(LIBSNDFILE) $(GTKLIBS) $(LIBTERMCAP)

--- a/build/MiBench/patches/MiBench/consumer/lame/runme_lame.sh
+++ b/build/MiBench/patches/MiBench/consumer/lame/runme_lame.sh
@@ -2,4 +2,4 @@
 
 ./unpack_input.sh "very_large.wav";
 
-./lame3.70/lame very_large.wav output_very_large.mp3
+./lame very_large.wav output_very_large.mp3

--- a/build/MiBench/patches/MiBench/consumer/typeset/lout-3.24/Makefile
+++ b/build/MiBench/patches/MiBench/consumer/typeset/lout-3.24/Makefile
@@ -346,6 +346,7 @@ OBJS	= z01.o z02.o z03.o z04.o z05.o z06.o z07.o z08.o	\
 lout:	$(OBJS)
 	$(LD) -o lout $(OBJS) $(ZLIB) -lm $(SB_OPT) 
 	chmod a+x lout
+	cp lout ..
 
 $(OBJS): externs.h
 

--- a/build/MiBench/patches/MiBench/consumer/typeset/runme_lout.sh
+++ b/build/MiBench/patches/MiBench/consumer/typeset/runme_lout.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./lout-3.24/lout -I lout-3.24/include -D lout-3.24/data -F lout-3.24/font -C lout-3.24/maps -H lout-3.24/hyph large.lout > output_large.ps
+./lout -I lout-3.24/include -D lout-3.24/data -F lout-3.24/font -C lout-3.24/maps -H lout-3.24/hyph large.lout > output_large.ps

--- a/build/MiBench/patches/MiBench/telecomm/gsm/Makefile
+++ b/build/MiBench/patches/MiBench/telecomm/gsm/Makefile
@@ -136,8 +136,8 @@ LFLAGS	= $(LDFLAGS) $(LDINC)
 
 LIBGSM	= $(LIB)/libgsm.a
 
-TOAST	= $(BIN)/toast
-UNTOAST	= $(BIN)/untoast
+TOAST	= toast
+UNTOAST	= untoast
 TCAT	= $(BIN)/tcat
 
 # Headers

--- a/build/MiBench/patches/MiBench/telecomm/gsm/runme_toast.sh
+++ b/build/MiBench/patches/MiBench/telecomm/gsm/runme_toast.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./bin/toast -fps -c data/large.au > output_large.encode.gsm
+./toast -fps -c data/large.au > output_large.encode.gsm

--- a/build/MiBench/patches/MiBench/telecomm/gsm/runme_untoast.sh
+++ b/build/MiBench/patches/MiBench/telecomm/gsm/runme_untoast.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./bin/untoast -fps -c data/large.au.run.gsm > output_large.decode.run
+./untoast -fps -c data/large.au.run.gsm > output_large.decode.run


### PR DESCRIPTION
All binaries that are executed are now directly inside the benchmarks dir so that when NOELLE runs make binary ; make run the binaries executed by runme_BENCHMARK.sh are those generated by NOELLE and not the default ones.