### PR TITLE
Fixed bc cmp mismatch in noelleGym.

### DIFF
--- a/build/MiBench/scripts/setup.sh
+++ b/build/MiBench/scripts/setup.sh
@@ -19,6 +19,23 @@ function split {
   return ;
 }
 
+function rm_all_bc_files_but {
+  local benchmarkDir="${1}" ;
+  local bcFileToNotRemove="`basename ${benchmarkDir}`.bc" ;
+
+  cd ${benchmarkDir} ;
+
+  for elem in `ls *.bc` ; do
+    if [ "${elem}" == "${bcFileToNotRemove}" ] ; then
+      continue ;
+    fi
+    
+    rm ${elem} ;
+  done
+
+  return ;
+}
+
 function genInputBenchmark {
   # Get function args
   benchmarkArg="${1}" ;
@@ -69,6 +86,10 @@ function genInputBenchmark {
 
   # The current dir has everything we need to run the program, let's copy it into our benchmarks dir
   cp -r ./* ${pathToBenchmark}/ ;
+
+  # Remove all bitcode files except current_benchmark.bc
+  # We need this because MiBench has multiple benchmarks in the same dir
+  $(rm_all_bc_files_but "${pathToBenchmark}") ;
 
   return ;
 }


### PR DESCRIPTION
MiBench keeps multiple benchmarks in one dir, so we need to remove the bitocode files of the other benchmarks in that dir before copying the rest of the files (like the inputs) over into MiBench/benchmarks.